### PR TITLE
fix regarding git remote handling

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 1.19 - Unreleased
 -----------------
 
+* Git: Don't stop buildout after renaming/adding git remotes, i.e. when
+  actively working on a given package.
+  [witsch]
+
 * Bugfix: Honhour buildout:develop parameters even if ending with slash
   [lukenowak]
 

--- a/src/mr/developer/git.py
+++ b/src/mr/developer/git.py
@@ -136,7 +136,7 @@ class GitWorkingCopy(common.BaseWorkingCopy):
             elif self.matches():
                 self.output((logger.info, "Skipped checkout of existing package '%s'." % name))
             else:
-                raise GitError("Checkout URL for existing package '%s' differs. Expected '%s'." % (name, self.source['url']))
+                self.output((logger.warning, "Checkout URL for existing package '%s' differs. Expected '%s'." % (name, self.source['url'])))
         else:
             return self.git_checkout(**kwargs)
 
@@ -157,7 +157,7 @@ class GitWorkingCopy(common.BaseWorkingCopy):
     def update(self, **kwargs):
         name = self.source['name']
         if not self.matches():
-            raise GitError("Can't update package '%s' because its URL doesn't match." % name)
+            self.output((logger.warning, "Can't update package '%s' because its URL doesn't match." % name))
         if self.status() != 'clean' and not kwargs.get('force', False):
             raise GitError("Can't update package '%s' because it's dirty." % name)
         return self.git_update(**kwargs)


### PR DESCRIPTION
buildout should not stop when the user has added/renamed their remotes.  this very likely indicates that they are actively working on that package and have added a remote pointing at their own fork.  imho, in that case the desired behavior is to issue a warning, but go through with the buildout nevertheless...
