### PR TITLE
Python 3 support.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,10 @@ try:
 except ImportError:
     install_requires.append('argparse')
 
+extra = {}
+if sys.version_info >= (3,):
+    extra['use_2to3'] = True
+
 setup(name='mr.developer',
       version=version,
       description="A zc.buildout extension to ease the development of large projects with lots of packages.",
@@ -48,4 +52,5 @@ setup(name='mr.developer',
       [zc.buildout.extension]
       default = mr.developer.extension:extension
       """,
+      **extra
       )


### PR DESCRIPTION
Add use_2to3 to setup.py so distribute under Python 3 will run 2to3 on build without impacting Python 2.x support.

See: http://packages.python.org/distribute/python3.html

Tested & working under Python 3.2 with zc.buildout 2.0.0a1
