### PR TITLE
Fix error with verbose status for filesystem and gitsvn sources

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.22 - Unreleased
 -----------------
 
-
+* Fixed ValueError in verbose status for filesystem and gitsvn sources.
+  [maurits]
 
 1.21 - 2012-04-11
 -----------------

--- a/src/mr/developer/filesystem.py
+++ b/src/mr/developer/filesystem.py
@@ -26,6 +26,8 @@ class FilesystemWorkingCopy(common.BaseWorkingCopy):
         return os.path.split(self.source['path'])[1] == self.source['url']
 
     def status(self, **kwargs):
+        if kwargs.get('verbose', False):
+            return 'clean', ''
         return 'clean'
 
     def update(self, **kwargs):

--- a/src/mr/developer/gitsvn.py
+++ b/src/mr/developer/gitsvn.py
@@ -53,6 +53,8 @@ class GitSVNWorkingCopy(SVNWorkingCopy):
         if svn_status == 'clean':
             return common.workingcopytypes['git'](self.source).status(**kwargs)
         else:
+            if kwargs.get('verbose', False):
+                return svn_status, ''
             return svn_status
 
 common.workingcopytypes['gitsvn'] = GitSVNWorkingCopy


### PR DESCRIPTION
I was getting this error when requesting a verbose status for fs sources:

``` python
$ bin/develop st -v

Traceback (most recent call last):
  File "bin/develop", line 15, in <module>
    mr.developer.develop.develop()
  File "/Users/mauritsvanrees/shared-eggs/mr.developer-1.21-py2.6.egg/mr/developer/develop.py", line 808, in __call__
    args.func(args)
  File "/Users/mauritsvanrees/shared-eggs/mr.developer-1.21-py2.6.egg/mr/developer/develop.py", line 673, in __call__
    status, output = workingcopies.status(source, verbose=True)
ValueError: too many values to unpack
```

This pull request fixes it for filesystem and gitsvn sources; I did not test gitsvn actually.
