### PR TITLE
Make mr.developer find git.exe on Windows

### DIFF
--- a/src/mr/developer/git.py
+++ b/src/mr/developer/git.py
@@ -24,7 +24,7 @@ class GitWorkingCopy(common.BaseWorkingCopy):
     # should make master and a lot of other conventional stuff configurable
     _upstream_name = "origin"
 
-    _executable_names = ['git', 'git.cmd']
+    _executable_names = ['git', 'git.cmd', 'git.exe']
 
     def __init__(self, source):
         self.git_executable = common.which(*self._executable_names)


### PR DESCRIPTION
Hi Florian,

A quick-and-dirty fix for the error "mr.developer: Cannot find git executable in PATH" on Windows.

Even better would be to loop over values in the PATHEXT environment variable?
See http://www.voidspace.org.uk/python/articles/command_line.shtml#pathext

(This is my first pull request ever in github, so plz bear with me...)
