### PR TITLE
Update src/mr/developer/svn.py

### DIFF
--- a/src/mr/developer/svn.py
+++ b/src/mr/developer/svn.py
@@ -297,7 +297,7 @@ class SVNWorkingCopy(common.BaseWorkingCopy):
         if url.endswith('/'):
             url = url[:-1]
         if rev is None:
-            rev = ''
+            rev = info.get('revision')
         if rev.startswith('>='):
             return (info.get('url') == url) and (int(info.get('revision')) >= int(rev[2:]))
         elif rev.startswith('>'):


### PR DESCRIPTION
The fix for #37 (released in 1.22) breaks any svn checkout without a revision specified.

The old code in `matches` (<=1.21) defaulted to setting the revision to the one returned in the info dictionary so the final comparison would succeed if no revision was specified in the url, but the new one sets the revision to an empty string in this case causing checkouts to throw a spurious message about packages being dirty.

I haven't run the tests (sorry!) but it looks like this is all that's required to fix it.
