### PR TITLE
Fixed repository url-matching in git.py

### DIFF
--- a/src/mr/developer/git.py
+++ b/src/mr/developer/git.py
@@ -232,6 +232,7 @@ class GitWorkingCopy(common.BaseWorkingCopy):
         stdout, stderr = cmd.communicate()
         if cmd.returncode != 0:
             raise GitError("git remote of '%s' failed.\n%s" % (name, stderr))
+        stdout = stdout.decode()
         return (self.source['url'] in stdout.split())
 
     def update(self, **kwargs):


### PR DESCRIPTION
The offending line was return (self.source['url'] in stdout.split()).
Since stdout is of type bytes and self.source['url'] of type str we have
to decode stdout with stdout.decode() before comparing.
