### PR TITLE
skip update of linked sources

### DIFF
--- a/src/mr/developer/common.py
+++ b/src/mr/developer/common.py
@@ -251,6 +251,9 @@ class WorkingCopies(object):
             update = wc.should_update(**kwargs)
             if not source.exists():
                 pass
+            elif os.path.islink(source['path']):
+                logger.info("Skipped update of linked '%s'." % name)
+                continue
             elif update and wc.status() != 'clean' and not kw.get('force', False):
                 print >>sys.stderr, "The package '%s' is dirty." % name
                 answer = yesno("Do you want to update it anyway?", default=False, all=True)


### PR DESCRIPTION
Theory being, that a user who replaces a mr.developer managed source
with a link wants mr.developer to treat the source as present without
touching it, leaving full control of the source to the user.
