### PR TITLE
Returns all eggs, including the source lines without eggs=false

### DIFF
--- a/src/mr/developer/extension.py
+++ b/src/mr/developer/extension.py
@@ -179,7 +179,8 @@ class Extension(object):
                     if name in versions:
                         del versions[name]
         develop = []
-        for path in [develeggs[k] for k in develeggs_order]:
+        ordered_keys = develeggs_order + [k for k in develeggs if k not in develeggs_order]
+        for path in [develeggs[k] for k in ordered_keys]:
             if path.startswith(self.buildout_dir):
                 develop.append(path[len(self.buildout_dir) + 1:])
             else:


### PR DESCRIPTION
Restores previous behavior concerning eggs defined in the "sources" section. Installation happens after the eggs defined in the "develop" tag inside the "buildout" section.

This fixes the regression observed by @timwintle at #135.
