### PR TITLE
Fix regression introduced by 1.29 release when `develop =` is empty and using `sources`

### DIFF
--- a/src/mr/developer/extension.py
+++ b/src/mr/developer/extension.py
@@ -176,6 +176,7 @@ class Extension(object):
                                 continue
                         config_develop.setdefault(name, True)
                     develeggs[name] = path
+                    develeggs_order.append(name)
                     if name in versions:
                         del versions[name]
         develop = []


### PR DESCRIPTION
Make sure to include the items in sources to the `develeggs_order` list so they aren't ignored

This fixes the issue I reported in https://github.com/fschulze/mr.developer/issues/137 with the 1.29 release
