### PR TITLE
Fix unpinning of eggs with a name containing characters not in [^A-Za-z0...

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,10 @@ Changelog
 1.34 - Unreleased
 -----------------
 
+* Fix unpinning of eggs with a name containing characters not in [^A-Za-z0-9.]
+  This means that to correctly unpin pkg.foo_bar we have to delete from buildout [version] section
+  pkg.foo-bar
+  [ale-rt]
 
 
 1.33 - 2015-05-25
@@ -26,7 +30,6 @@ Changelog
 
 * Raise an exception if the sources section references a missing section.
   [icemac (Michael Howitz)]
-
 
 1.31 - 2014-10-29
 -----------------

--- a/src/mr/developer/extension.py
+++ b/src/mr/developer/extension.py
@@ -1,4 +1,5 @@
 from mr.developer.common import memoize, WorkingCopies, Config, get_workingcopytypes
+from setuptools.package_index import safe_name
 import logging
 import os
 import re
@@ -202,8 +203,8 @@ class Extension(object):
                         config_develop.setdefault(name, True)
                     develeggs[name] = path
                     develeggs_order.append(name)
-                    if name in versions:
-                        del versions[name]
+                    if safe_name(name) in versions:
+                        del versions[safe_name(name)]
         develop = []
         for path in [develeggs[k] for k in develeggs_order]:
             if path.startswith(self.buildout_dir):

--- a/src/mr/developer/tests/test_extension.py
+++ b/src/mr/developer/tests/test_extension.py
@@ -272,6 +272,37 @@ class TestExtensionClass(TestCase):
         self.assertEqual(develeggs['slash'], '/develop/with/slash/')
         self.assertEqual(develeggs['develop'], '/normal/develop')
 
+    def testDevelopSafeName(self):
+        '''We have two source packages:
+         - pkg.bar_foo
+         - pkg.foo_bar
+        both of the hae a version picked.
+
+        If we auto-checkout pkg.foo_bar it gets unpinned!
+        '''
+        self.buildout['sources'].update({
+            'pkg.bar_foo': 'svn dummy://pkg.bar_foo',
+            'pkg.foo_bar': 'svn dummy://pkg.foo_bar',
+        })
+        self.buildout['buildout']['auto-checkout'] = 'pkg.foo_bar'
+        self.buildout._raw['buildout']['versions'] = 'versions'
+        self.buildout._raw['versions'] = {
+            'pkg.foo-bar': '1.0',
+            'pkg.bar-foo': '1.0',
+        }
+        _exists = patch('os.path.exists')
+        exists = _exists.__enter__()
+        try:
+            exists().return_value = True
+
+            (develop, develeggs, versions) = self.extension.get_develop_info()
+        finally:
+            _exists.__exit__()
+        self.assertEqual(
+            self.buildout['versions'],
+            {'pkg.bar-foo': '1.0'}
+        )
+
     def testDevelopOrder(self):
         self.buildout['buildout']['develop'] = '/normal/develop ' \
             '/develop/with/slash/'


### PR DESCRIPTION
Fix unpinning of eggs with a name containing characters not in [^A-Za-z0-9.]
This means that to correctly unpin pkg.foo_bar we have to delete from buildout [version] section pkg.foo-bar
