### PR TITLE
Raise an exception if the sources section references a missing section

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,8 +4,7 @@ Changelog
 1.32 - Unreleased
 -----------------
 
-* Raise exception sources section cannot be computed due to a missing needed
-  section instead of ignoring the error.
+* Raise an exception if the sources section references a missing section.
   [icemac (Michael Howitz)]
 
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.32 - Unreleased
 -----------------
 
+* Raise exception sources section cannot be computed due to a missing needed
+  section instead of ignoring the error.
+  [icemac (Michael Howitz)]
 
 
 1.31 - 2014-10-29

--- a/src/mr/developer/extension.py
+++ b/src/mr/developer/extension.py
@@ -52,7 +52,7 @@ class Extension(object):
         sources_dir = self.get_sources_dir()
         sources = {}
         sources_section = self.buildout['buildout'].get('sources', 'sources')
-        section = self.buildout.get(sources_section, {})
+        section = self.buildout[sources_section]
         workingcopytypes = get_workingcopytypes()
         for name in section:
             info = section[name].split()

--- a/src/mr/developer/extension.py
+++ b/src/mr/developer/extension.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import sys
+import zc.buildout.buildout
 
 
 FAKE_PART_ID = '_mr.developer'
@@ -52,7 +53,13 @@ class Extension(object):
         sources_dir = self.get_sources_dir()
         sources = {}
         sources_section = self.buildout['buildout'].get('sources', 'sources')
-        section = self.buildout[sources_section]
+        try:
+            section = self.buildout[sources_section]
+        except zc.buildout.buildout.MissingSection as e:
+            if e.message == sources_section:
+                section = {}
+            else:
+                raise
         workingcopytypes = get_workingcopytypes()
         for name in section:
             info = section[name].split()


### PR DESCRIPTION
Raise an exception if the sources section references a missing section.
Normally buildout raises an error in such a case but I have a complex buildout here where this does not happen but mr.developer eats the exception and does not checkout or list any sources.

See the following example to explain:

```ini
[buildout]
extensions = mr.developer
sources = sources
auto-checkout = *

[vcs]
github = git https://github.com

[sources]
bowerstatic = ${typo-in-name-vcs:github}/gocept/bowerstatic.git
```

The error is in the ```[sources]``` section referencing an unknown section.
This easy example does not fail. But somehow in a more complex buildout with many extends buildout does not raise an error.