### PR TITLE
Fix git-clone-depth

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.33 - Unreleased
 -----------------
 
-
+* Fix git-clone-depth global option, it needs to be kept as a string and not
+  converted to a number.
+  [gforcada (Gil Forcada)]
 
 1.32 - 2015-05-23
 -----------------

--- a/src/mr/developer/extension.py
+++ b/src/mr/developer/extension.py
@@ -115,7 +115,7 @@ class Extension(object):
                         value = False
                 if key == 'depth':
                     try:
-                        value = int(value)
+                        not_used = int(value)  # noqa
                     except ValueError:
                         raise ValueError('depth value needs to be a number.')
                 source[key] = value
@@ -167,7 +167,7 @@ class Extension(object):
         value = self.buildout['buildout'].get('git-clone-depth', '')
         if value:
             try:
-                value = int(value)
+                not_used = int(value)  # noqa
             except ValueError:
                 raise ValueError('git-clone-depth needs to be a number.')
         return value


### PR DESCRIPTION
Oops! :blush: 

subprocess.Popen expects that all values are strings.

So it only needs to be checked that it is a number but
keeping it as a string.

 As I couldn't test it locally (no idea on how to do so) that part was not tested enough.

This should fix it.