### PR TITLE
Checkout branch on clone

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,8 @@ Changelog
 1.34 - Unreleased
 -----------------
 
+* Checkout branch when cloning a git repository.
+  [gforcada]
 
 
 1.33 - 2015-05-25

--- a/src/mr/developer/git.py
+++ b/src/mr/developer/git.py
@@ -142,12 +142,14 @@ class GitWorkingCopy(common.BaseWorkingCopy):
         args = ["clone", "--quiet"]
         if 'depth' in self.source:
             args.extend(["--depth", self.source["depth"]])
+        if "branch" in self.source:
+            args.extend(["-b", self.source["branch"]])
         args.extend([url, path])
         cmd = self.run_git(args)
         stdout, stderr = cmd.communicate()
         if cmd.returncode != 0:
             raise GitError("git cloning of '%s' failed.\n%s" % (name, stderr))
-        if 'branch' in self.source or 'rev' in self.source:
+        if 'rev' in self.source:
             stdout, stderr = self.git_switch_branch(stdout, stderr)
         if 'pushurl' in self.source:
             stdout, stderr = self.git_set_pushurl(stdout, stderr)


### PR DESCRIPTION
If a source defines a branch, switch to it when cloning.

This helps when used in combination with ``--depth``, as git will already
download the history defined by ``--depth`` from that branch instead of
master.