### PR TITLE
Fix issue 162: switching to git branch from revision

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,13 @@ Changelog
 1.34 - Unreleased
 -----------------
 
+* Fix switching to git branch from revision.  When currently you are
+  not on a git branch (for example on a tag), running a develop update
+  would try to pull and fail.  Now we simply fetch, and handle
+  possible branch switching and merging the same as we always do.
+  Fixes issue #162
+  [maurits]
+
 * Fix unpinning of eggs with a name containing characters not in [^A-Za-z0-9.]
   This means that to correctly unpin pkg.foo_bar we have to delete
   ``pkg.foo-bar`` from the buildout ``[version]`` section.

--- a/src/mr/developer/git.py
+++ b/src/mr/developer/git.py
@@ -209,16 +209,12 @@ class GitWorkingCopy(common.BaseWorkingCopy):
         name = self.source['name']
         path = self.source['path']
         self.output((logger.info, "Updated '%s' with git." % name))
-        if 'rev' in self.source:
-            # Specific revision, so we only fetch.  Pull is fetch plus
-            # merge, which is not possible here.
-            argv = ["fetch"]
-        else:
-            argv = ["pull"]
+        # First we fetch.  This should always be possible.
+        argv = ["fetch"]
         cmd = self.run_git(argv, cwd=path)
         stdout, stderr = cmd.communicate()
         if cmd.returncode != 0:
-            raise GitError("git pull of '%s' failed.\n%s" % (name, stderr))
+            raise GitError("git fetch of '%s' failed.\n%s" % (name, stderr))
         if 'rev' in self.source:
             stdout, stderr = self.git_switch_branch(stdout, stderr)
         elif 'branch' in self.source:

--- a/src/mr/developer/tests/test_git.py
+++ b/src/mr/developer/tests/test_git.py
@@ -161,6 +161,25 @@ class GitTests(JailSetup):
         CmdUpdate(develop)(develop.parser.parse_args(['up', 'egg']))
         assert set(os.listdir(os.path.join(src, 'egg'))) == set(('.git', 'bar', 'foo'))
 
+        # Switch to specific revision, then switch back to master branch.
+        develop.sources = {
+            'egg': Source(
+                kind='git',
+                name='egg',
+                rev=rev,
+                url='%s' % repository,
+                path=os.path.join(src, 'egg'))}
+        CmdUpdate(develop)(develop.parser.parse_args(['up', 'egg']))
+        assert set(os.listdir(os.path.join(src, 'egg'))) == set(('.git', 'foo', 'foo2'))
+        develop.sources = {
+            'egg': Source(
+                kind='git',
+                name='egg',
+                url='%s' % repository,
+                path=os.path.join(src, 'egg'))}
+        CmdUpdate(develop)(develop.parser.parse_args(['up', 'egg']))
+        assert set(os.listdir(os.path.join(src, 'egg'))) == set(('.git', 'bar', 'foo'))
+
         CmdStatus(develop)(develop.parser.parse_args(['status']))
 
         # we can't use both rev and branch

--- a/test.sh
+++ b/test.sh
@@ -7,4 +7,4 @@ if $($PYTHON --version >/dev/null 2>&1); then
 else
     export PYTHON_VERSION="Python 2.4.x"
 fi
-./bin/py.test --cov src/mr/developer
+./bin/py.test --cov src/mr/developer $*


### PR DESCRIPTION
When currently you are not on a git branch (for example on a tag), running a develop update would try to pull and fail.  Now we simply fetch, and handle possible branch switching and merging the same as we always do.

Includes test. Woohoo! ;-)