### PR TITLE
Use the which('git') functionality also for all other executables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ Changelog
   3.2 or higher.
   [reinout]
 
+* Report missing executables (like 'hg') instead of reporting a too-generic
+  "file not found" error.
+  [reinout]
+
 * Fix bug with assignments lacking the section.  According to
   buildout's documentation ``option=value`` is equivalent to
   ``buildout:option=value``.

--- a/src/mr/developer/bazaar.py
+++ b/src/mr/developer/bazaar.py
@@ -10,6 +10,11 @@ class BazaarError(common.WCError):
 
 
 class BazaarWorkingCopy(common.BaseWorkingCopy):
+
+    def __init__(self, source):
+        super(BazaarWorkingCopy, self).__init__(source)
+        self.bzr_executable = common.which('bzr')
+
     def bzr_branch(self, **kwargs):
         name = self.source['name']
         path = self.source['path']
@@ -22,7 +27,7 @@ class BazaarWorkingCopy(common.BaseWorkingCopy):
         env = dict(os.environ)
         env.pop('PYTHONPATH', None)
         cmd = subprocess.Popen(
-            ['bzr', 'branch', '--quiet', url, path],
+            [self.bzr_executable, 'branch', '--quiet', url, path],
             env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = cmd.communicate()
         if cmd.returncode != 0:
@@ -38,7 +43,7 @@ class BazaarWorkingCopy(common.BaseWorkingCopy):
         self.output((logger.info, 'Updated %r with bazaar.' % name))
         env = dict(os.environ)
         env.pop('PYTHONPATH', None)
-        cmd = subprocess.Popen(['bzr', 'pull', url], cwd=path,
+        cmd = subprocess.Popen([self.bzr_executable, 'pull', url], cwd=path,
             env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = cmd.communicate()
         if cmd.returncode != 0:
@@ -70,7 +75,7 @@ class BazaarWorkingCopy(common.BaseWorkingCopy):
         env = dict(os.environ)
         env.pop('PYTHONPATH', None)
         cmd = subprocess.Popen(
-            ['bzr', 'info'], cwd=path,
+            [self.bzr_executable, 'info'], cwd=path,
             env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = cmd.communicate()
         if cmd.returncode != 0:
@@ -83,7 +88,7 @@ class BazaarWorkingCopy(common.BaseWorkingCopy):
         env = dict(os.environ)
         env.pop('PYTHONPATH', None)
         cmd = subprocess.Popen(
-            ['bzr', 'status'], cwd=path,
+            [self.bzr_executable, 'status'], cwd=path,
             env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = cmd.communicate()
         status = stdout and 'dirty' or 'clean'

--- a/src/mr/developer/common.py
+++ b/src/mr/developer/common.py
@@ -57,7 +57,8 @@ def which(name_root):
             if is_exe(exe_file):
                 return exe_file
 
-    return None
+    logger.error("Cannot find executable %s in PATH", name_root)
+    sys.exit(1)
 
 
 def version_sorted(inp, *args, **kwargs):

--- a/src/mr/developer/cvs.py
+++ b/src/mr/developer/cvs.py
@@ -37,7 +37,7 @@ def build_cvs_command(command, name, url, tag='', cvs_root='', tag_file=None):
     if command == 'status':
         return ['cvs', '-q', '-n', 'update']
 
-    cmd = ['cvs']
+    cmd = [common.which('cvs')]
     if cvs_root:
         cmd.extend(['-d', cvs_root])
 

--- a/src/mr/developer/cvs.py
+++ b/src/mr/developer/cvs.py
@@ -37,7 +37,7 @@ def build_cvs_command(command, name, url, tag='', cvs_root='', tag_file=None):
     if command == 'status':
         return ['cvs', '-q', '-n', 'update']
 
-    cmd = [common.which('cvs')]
+    cmd = ['cvs']
     if cvs_root:
         cmd.extend(['-d', cvs_root])
 

--- a/src/mr/developer/darcs.py
+++ b/src/mr/developer/darcs.py
@@ -11,6 +11,11 @@ class DarcsError(common.WCError):
 
 
 class DarcsWorkingCopy(common.BaseWorkingCopy):
+
+    def __init__(self, source):
+        super(DarcsWorkingCopy, self).__init__(source)
+        self.darcs_executable = common.which('darcs')
+
     def darcs_checkout(self, **kwargs):
         name = self.source['name']
         path = self.source['path']
@@ -19,7 +24,7 @@ class DarcsWorkingCopy(common.BaseWorkingCopy):
             self.output((logger.info, "Skipped getting of existing package '%s'." % name))
             return
         self.output((logger.info, "Getting '%s' with darcs." % name))
-        cmd = ["darcs", "get", "--quiet", "--lazy", url, path]
+        cmd = [self.darcs_executable, "get", "--quiet", "--lazy", url, path]
         cmd = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = cmd.communicate()
         if cmd.returncode != 0:
@@ -31,7 +36,7 @@ class DarcsWorkingCopy(common.BaseWorkingCopy):
         name = self.source['name']
         path = self.source['path']
         self.output((logger.info, "Updating '%s' with darcs." % name))
-        cmd = subprocess.Popen(["darcs", "pull", "-a"],
+        cmd = subprocess.Popen([self.darcs_executable, "pull", "-a"],
                                cwd=path,
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
@@ -63,7 +68,7 @@ class DarcsWorkingCopy(common.BaseWorkingCopy):
             for line in open(repos).readlines():
                 yield line.strip()
         else:
-            cmd = subprocess.Popen(["darcs", "show", "repo"],
+            cmd = subprocess.Popen([self.darcs_executable, "show", "repo"],
                                    cwd=path,
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE)
@@ -89,7 +94,7 @@ class DarcsWorkingCopy(common.BaseWorkingCopy):
 
     def status(self, **kwargs):
         path = self.source['path']
-        cmd = subprocess.Popen(["darcs", "whatsnew"],
+        cmd = subprocess.Popen([self.darcs_executable, "whatsnew"],
                                cwd=path,
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)

--- a/src/mr/developer/git.py
+++ b/src/mr/developer/git.py
@@ -27,9 +27,6 @@ class GitWorkingCopy(common.BaseWorkingCopy):
 
     def __init__(self, source):
         self.git_executable = common.which('git')
-        if self.git_executable is None:
-            logger.error("Cannot find git executable in PATH")
-            sys.exit(1)
         if 'rev' in source and 'revision' in source:
             raise ValueError("The source definition of '%s' contains "
                              "duplicate revision options." % source['name'])

--- a/src/mr/developer/gitsvn.py
+++ b/src/mr/developer/gitsvn.py
@@ -12,11 +12,15 @@ class GitSVNError(common.WCError):
 
 class GitSVNWorkingCopy(SVNWorkingCopy):
 
+    def __init__(self, source):
+        super(GitSVNWorkingCopy, self).__init__(source)
+        self.gitify_executable = common.which('gitify')
+
     def gitify_init(self, **kwargs):
         name = self.source['name']
         path = self.source['path']
         self.output((logger.info, "Gitified '%s'." % name))
-        cmd = subprocess.Popen(["gitify", "init"],
+        cmd = subprocess.Popen([self.gitify_executable, "init"],
             cwd=path,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)
@@ -38,7 +42,7 @@ class GitSVNWorkingCopy(SVNWorkingCopy):
         name = self.source['name']
         path = self.source['path']
         self.output((logger.info, "Updated '%s' with gitify." % name))
-        cmd = subprocess.Popen(["gitify", "update"],
+        cmd = subprocess.Popen([self.gitify_executable, "update"],
             cwd=path,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE)

--- a/src/mr/developer/mercurial.py
+++ b/src/mr/developer/mercurial.py
@@ -14,6 +14,7 @@ class MercurialError(common.WCError):
 class MercurialWorkingCopy(common.BaseWorkingCopy):
 
     def __init__(self, source):
+        self.hg_executable = common.which('hg')
         source.setdefault('branch', 'default')
         source.setdefault('rev')
         super(MercurialWorkingCopy, self).__init__(source)
@@ -31,7 +32,7 @@ class MercurialWorkingCopy(common.BaseWorkingCopy):
         env = dict(os.environ)
         env.pop('PYTHONPATH', None)
         cmd = subprocess.Popen(
-            ['hg', 'clone', '--updaterev', rev, '--quiet', '--noninteractive', url, path],
+            [self.hg_executable, 'clone', '--updaterev', rev, '--quiet', '--noninteractive', url, path],
             env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = cmd.communicate()
         if cmd.returncode != 0:
@@ -62,7 +63,7 @@ class MercurialWorkingCopy(common.BaseWorkingCopy):
         env = dict(os.environ)
         env.pop('PYTHONPATH', None)
         cmd = subprocess.Popen(
-            ['hg', 'checkout', rev, '-c'],
+            [self.hg_executable, 'checkout', rev, '-c'],
             cwd=path, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = cmd.communicate()
         if cmd.returncode:
@@ -78,7 +79,7 @@ class MercurialWorkingCopy(common.BaseWorkingCopy):
         env.pop('PYTHONPATH', None)
         try:
             cmd = subprocess.Popen(
-                ['hg', 'tags'],
+                [self.hg_executable, 'tags'],
                 cwd=path, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except OSError:
             return []
@@ -120,7 +121,7 @@ class MercurialWorkingCopy(common.BaseWorkingCopy):
         env = dict(os.environ)
         env.pop('PYTHONPATH', None)
         cmd = subprocess.Popen(
-            ['hg', 'pull', '-u'],
+            [self.hg_executable, 'pull', '-u'],
             cwd=path, env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = cmd.communicate()
         if cmd.returncode != 0:
@@ -158,7 +159,7 @@ class MercurialWorkingCopy(common.BaseWorkingCopy):
         env = dict(os.environ)
         env.pop('PYTHONPATH', None)
         cmd = subprocess.Popen(
-            ['hg', 'showconfig', 'paths.default'], cwd=path,
+            [self.hg_executable, 'showconfig', 'paths.default'], cwd=path,
             env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = cmd.communicate()
         if cmd.returncode != 0:
@@ -172,13 +173,13 @@ class MercurialWorkingCopy(common.BaseWorkingCopy):
         env = dict(os.environ)
         env.pop('PYTHONPATH', None)
         cmd = subprocess.Popen(
-            ['hg', 'status'], cwd=path,
+            [self.hg_executable, 'status'], cwd=path,
             env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         stdout, stderr = cmd.communicate()
         status = stdout and 'dirty' or 'clean'
         if status == 'clean':
             cmd = subprocess.Popen(
-                ['hg', 'outgoing'], cwd=path,
+                [self.hg_executable, 'outgoing'], cwd=path,
                 env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             outgoing_stdout, stderr = cmd.communicate()
             stdout += b('\n') + outgoing_stdout

--- a/src/mr/developer/svn.py
+++ b/src/mr/developer/svn.py
@@ -72,12 +72,13 @@ class SVNWorkingCopy(common.BaseWorkingCopy):
 
     def __init__(self, *args, **kwargs):
         common.BaseWorkingCopy.__init__(self, *args, **kwargs)
+        self.svn_executable = common.which("svn")
         self._svn_check_version()
 
     def _svn_check_version(self):
         global _svn_version_warning
         try:
-            cmd = subprocess.Popen(["svn", "--version"],
+            cmd = subprocess.Popen([self.svn_executable, "--version"],
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE)
         except OSError:
@@ -172,7 +173,7 @@ class SVNWorkingCopy(common.BaseWorkingCopy):
         name = self.source['name']
         path = self.source['path']
         url = self.source['url']
-        args = ["svn", "checkout", url, path]
+        args = [self.svn_executable, "checkout", url, path]
         stdout, stderr, returncode = self._svn_communicate(args, url, **kwargs)
         if returncode != 0:
             raise SVNError("Subversion checkout for '%s' failed.\n%s" % (name, s(stderr)))
@@ -219,7 +220,7 @@ class SVNWorkingCopy(common.BaseWorkingCopy):
         if name in self._svn_info_cache:
             return self._svn_info_cache[name]
         path = self.source['path']
-        cmd = subprocess.Popen(["svn", "info", "--non-interactive", "--xml",
+        cmd = subprocess.Popen([self.svn_executable, "info", "--non-interactive", "--xml",
                                 path],
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
@@ -248,7 +249,7 @@ class SVNWorkingCopy(common.BaseWorkingCopy):
         name = self.source['name']
         path = self.source['path']
         url, rev = self._normalized_url_rev()
-        args = ["svn", "switch", url, path]
+        args = [self.svn_executable, "switch", url, path]
         if rev is not None and not rev.startswith('>'):
             args.insert(2, '-r%s' % rev)
         stdout, stderr, returncode = self._svn_communicate(args, url, **kwargs)
@@ -261,7 +262,7 @@ class SVNWorkingCopy(common.BaseWorkingCopy):
         name = self.source['name']
         path = self.source['path']
         url, rev = self._normalized_url_rev()
-        args = ["svn", "update", path]
+        args = [self.svn_executable, "update", path]
         if rev is not None and not rev.startswith('>'):
             args.insert(2, '-r%s' % rev)
         stdout, stderr, returncode = self._svn_communicate(args, url, **kwargs)
@@ -331,7 +332,7 @@ class SVNWorkingCopy(common.BaseWorkingCopy):
     def status(self, **kwargs):
         name = self.source['name']
         path = self.source['path']
-        cmd = subprocess.Popen(["svn", "status", "--xml", path],
+        cmd = subprocess.Popen([self.svn_executable, "status", "--xml", path],
                                stdout=subprocess.PIPE,
                                stderr=subprocess.PIPE)
         stdout, stderr = cmd.communicate()
@@ -350,7 +351,7 @@ class SVNWorkingCopy(common.BaseWorkingCopy):
         else:
             status = 'dirty'
         if kwargs.get('verbose', False):
-            cmd = subprocess.Popen(["svn", "status", path],
+            cmd = subprocess.Popen([self.svn_executable, "status", path],
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE)
             stdout, stderr = cmd.communicate()


### PR DESCRIPTION
Fixes #66 

As suggested by @fschulze: "In git.py we look up the executable first, which also makes it work on Windows".

I don't know if that means that mr.developer as a whole now works better on windows? I guess it doesn't make a difference. If it *does*, the changelog entry has to be expanded.