### PR TITLE
Improve error msg when dir isn't found in fs mode.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.35 - (unreleased)
+-----------------
+
+* Improve error message when a directory isn't found in fs mode.
+  [idgserpro]
+
 1.34 - 2015-09-30
 -----------------
 

--- a/src/mr/developer/filesystem.py
+++ b/src/mr/developer/filesystem.py
@@ -21,7 +21,9 @@ class FilesystemWorkingCopy(common.BaseWorkingCopy):
                     'Expected %r.' % (name, self.source['url']))
         else:
             raise FilesystemError(
-                'Directory for package %r doesn\'t exist.' % name)
+                "Directory %r for package %r doesn't exist. "
+                "Check in the documentation if you need to add/change a 'sources-dir' option in "
+                "your [buildout] section or a 'path' option in [sources]." % (path, name))
         return ''
 
     def matches(self):


### PR DESCRIPTION
This is useful specially for beginners using mr.developer for the first time.