### PR TITLE
Always use the stdlib configparser/ConfigParser, to avoid unicode/bytes confusion

### DIFF
--- a/src/mr/developer/common.py
+++ b/src/mr/developer/common.py
@@ -1,7 +1,3 @@
-try:
-    from configparser import RawConfigParser
-except ImportError:
-    from ConfigParser import RawConfigParser
 import logging
 import os
 import pkg_resources
@@ -14,6 +10,10 @@ import re
 import subprocess
 import sys
 import threading
+if sys.version_info < (3, ):
+    from ConfigParser import RawConfigParser
+else:
+    from configparser import RawConfigParser
 
 
 logger = logging.getLogger("mr.developer")

--- a/src/mr/developer/tests/test_common.py
+++ b/src/mr/developer/tests/test_common.py
@@ -1,3 +1,4 @@
+import tempfile
 from unittest import TestCase
 
 
@@ -41,6 +42,24 @@ class TestParseBuildoutArgs(TestCase):
         self.checkOptions(options)
         self.assertEquals(options[0], ('buildout', 'foo', '42'))
         self.assertEquals(len(args), 0)
+
+
+class TestConfigParser(TestCase):
+    def setUp(self):
+        from mr.developer.common import Config
+        self.Config = Config
+
+    def test_buildout_args_key_is_str(self):
+        config = self.Config('.')
+        with tempfile.NamedTemporaryFile() as config_file:
+            config_file.write(b'''[buildout]
+args = './bin/buildout'
+    '-c'
+    'buildout.cfg'
+''')
+            config_file.flush()
+            read_config = config.read_config(config_file.name)
+        self.assertEqual(type(read_config.get('buildout', 'args')), str)
 
 
 class TestRewrites(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35
+envlist = py26,py27,py{26,27}-configparser,py33,py34,py35
 
 [base]
 deps =
@@ -14,3 +14,4 @@ commands = py.test --cov {envsitepackagesdir}/mr/developer --cov-report=term --c
 deps =
     {[base]deps}
     pytest-cov
+    configparser: configparser


### PR DESCRIPTION
Do not use configparser in Python2, even if it is available, as buildout requires bytestrings in places on Python2 and unicode strings on Python3. Providing unicode strings in Python2 causes failure to parse the buildout args on Python27 with configparser installed.

For example, before this patch, if you have configparser installed globally (for example, as a dependency of flake8):

    MomCorp-Flagship:buildout.coredev matthewwilkes (5.1)$ ./bin/develop status
    Traceback (most recent call last):
      File "./bin/develop", line 13, in <module>
        sys.exit(mr.developer.develop.develop())
      File "/Users/matthewwilkes/.buildout/eggs/mr.developer-1.34-py2.7.egg/mr/developer/develop.py", line 89, in __call__
        self.config.buildout_settings['windows_restart'])
      File "/Users/matthewwilkes/.buildout/eggs/zc.buildout-2.7.0-py2.7.egg/zc/buildout/buildout.py", line 352, in __init__
        options[name+'-directory'] = d
      File "/Users/matthewwilkes/.buildout/eggs/zc.buildout-2.7.0-py2.7.egg/zc/buildout/buildout.py", line 1374, in __setitem__
        raise TypeError('Option values must be strings', value)
    TypeError: ('Option values must be strings', u'/Users/matthewwilkes/work/plone/repos/buildout.coredev/bin')
