### PR TITLE
Add the buildout option mr.developer-verbose 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ Changelog
 1.36 - Unreleased
 -----------------
 
+* Add the buildout option mr.developer-verbose that enables showing
+  the same out when running buildout as when running ./bin/develop up -v.
+  [sunew]
+
+* Respect the buildout -v setting for updates, just as it already does for checkouts.
+  [sunew]
 
 
 1.35 - 2017-02-01

--- a/src/mr/developer/extension.py
+++ b/src/mr/developer/extension.py
@@ -39,6 +39,10 @@ class Extension(object):
         return threads
 
     @memoize
+    def get_mrdev_verbose(self):
+        return self.buildout['buildout'].get('mr.developer-verbose', '').lower() == 'true'
+
+    @memoize
     def get_sources_dir(self):
         sources_dir = self.buildout['buildout'].get('sources-dir', 'src')
         if not os.path.isabs(sources_dir):
@@ -263,8 +267,9 @@ class Extension(object):
                     packages.add(pkg)
 
         offline = self.buildout['buildout'].get('offline', '').lower() == 'true'
+        verbose = root_logger.level <= 10 or self.get_mrdev_verbose()
         workingcopies.checkout(sorted(packages),
-                               verbose=root_logger.level <= 10,
+                               verbose=verbose,
                                update=always_checkout,
                                submodules=update_git_submodules,
                                always_accept_server_certificate=always_accept_server_certificate,

--- a/src/mr/developer/git.py
+++ b/src/mr/developer/git.py
@@ -243,7 +243,7 @@ class GitWorkingCopy(common.BaseWorkingCopy):
         update = self.should_update(**kwargs)
         if os.path.exists(path):
             if update:
-                self.update(**kwargs)
+                return self.update(**kwargs)
             elif self.matches():
                 self.output((logger.info, "Skipped checkout of existing package '%s'." % name))
             else:


### PR DESCRIPTION
that enables showing the same out when running buildout as when running ./bin/develop up -v.

Respect the buildout -v setting for updates, just as it already does for checkouts.

Valuable in many cases to see the output of the git command - to see is actually updated.