### PR TITLE
Set empty version pin for develop packages instead of removing the version pin from the section.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ Changelog
 * Use ``from __future__ import print_function`` to fix output of ``help --rst``.
   [fschulze]
 
+* Set empty version pin for develop packages instead of removing the version
+  pin from the section.
+  [fschulze]
+
 
 1.37 (2017-03-04)
 -----------------

--- a/src/mr/developer/extension.py
+++ b/src/mr/developer/extension.py
@@ -182,7 +182,7 @@ class Extension(object):
         sources = self.get_sources()
         develop = self.buildout['buildout'].get('develop', '')
         versions_section = self.buildout['buildout'].get('versions')
-        versions = self.buildout.get(versions_section, {})
+        versions = self.buildout._raw.get(versions_section, {})
         develeggs = {}
         develeggs_order = []
         for path in develop.split():
@@ -207,8 +207,7 @@ class Extension(object):
                         config_develop.setdefault(name, True)
                     develeggs[name] = path
                     develeggs_order.append(name)
-                    if safe_name(name) in versions:
-                        del versions[safe_name(name)]
+                    versions[safe_name(name)] = ''
         develop = []
         for path in [develeggs[k] for k in develeggs_order]:
             if path.startswith(self.buildout_dir):

--- a/src/mr/developer/tests/test_extension.py
+++ b/src/mr/developer/tests/test_extension.py
@@ -272,7 +272,9 @@ class TestExtensionClass:
             (develop, develeggs, versions) = extension.get_develop_info()
         finally:
             _exists.__exit__()
-        assert buildout['versions'] == {'pkg.bar-foo': '1.0'}
+        assert buildout['versions'] == {
+            'pkg.foo-bar': '',
+            'pkg.bar-foo': '1.0'}
 
     def testDevelopOrder(self, buildout, extension):
         buildout['buildout']['develop'] = '/normal/develop ' \

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist = py26,py27,py{26,27}-configparser,py33,py34,py35,py36
 [base]
 deps =
     mock
-    zc.buildout
     pytest
     pytest-flakes
     pytest-pep8
@@ -15,3 +14,4 @@ deps =
     {[base]deps}
     pytest-cov
     configparser: configparser
+    py26: zc.buildout<=2.5.3


### PR DESCRIPTION
Could someone test this with buildout.coredev?

You have to manually add mr.developer as develop package in the buildout config. Because mr.developer is a buildout extension, it doesn't work on itself.