### PR TITLE
Clean after updating with git.

### DIFF
--- a/src/mr/developer/git.py
+++ b/src/mr/developer/git.py
@@ -239,6 +239,8 @@ class GitWorkingCopy(common.BaseWorkingCopy):
                 stdout, stderr = self.git_update_submodules(stdout, stderr, submodule=submodule)
                 self.output((logger.info, "Initialized '%s' submodule at '%s' with git." % (name, submodule)))
 
+        self.run_git(["clean", "-f", "-X", "-d"])  # Remove .pycs
+
         if kwargs.get('verbose', False):
             return stdout
 


### PR DESCRIPTION
If the repo your working with removes a python module, mr.developer leaved `.pyc` files behind.  This may hurt your ability to test that other modules are properly updated (by not importing the removed module).