### PR TITLE
use universal_newlines instead of compat to deal with output for git

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.38 (Unreleased)
 -----------------
 
+* Use universal_newlines to deal with all output for git.
+  [pbauer]
+
 * Fix verbose status in python 3.
   [pbauer]
 

--- a/src/mr/developer/commands.py
+++ b/src/mr/developer/commands.py
@@ -765,9 +765,9 @@ class CmdStatus(Command):
             info.append(name)
             print(" ".join(info))
             if args.verbose:
-                output = output.strip().decode('utf8')
                 if six.PY3 and isinstance(output, six.binary_type):
                     output = output.decode('utf8')
+                output = output.strip()
                 if output:
                     for line in output.split('\n'):
                         print("      %s" % line)

--- a/src/mr/developer/common.py
+++ b/src/mr/developer/common.py
@@ -8,6 +8,7 @@ except ImportError:
     import Queue as queue
 import re
 import subprocess
+import six
 import sys
 import threading
 if sys.version_info < (3, ):
@@ -180,6 +181,8 @@ def worker(working_copies, the_queue):
             for lvl, msg in wc._output:
                 lvl(msg)
             if kwargs.get('verbose', False) and output is not None and output.strip():
+                if six.PY3 and isinstance(output, six.binary_type):
+                    output = output.decode('utf8')
                 print(output)
             output_lock.release()
 

--- a/src/mr/developer/git.py
+++ b/src/mr/developer/git.py
@@ -218,7 +218,6 @@ class GitWorkingCopy(common.BaseWorkingCopy):
         cmd = self.run_git(argv, cwd=path)
         stdout, stderr = cmd.communicate()
         if cmd.returncode != 0:
-            import pdb; pdb.set_trace()
             raise GitError("git fetch of '%s' failed.\n%s" % (name, stderr))
         if 'rev' in self.source:
             stdout, stderr = self.git_switch_branch(stdout, stderr)

--- a/src/mr/developer/git.py
+++ b/src/mr/developer/git.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 from mr.developer import common
-from mr.developer.compat import b, s
 import os
 import subprocess
 import re
@@ -50,7 +49,7 @@ class GitWorkingCopy(common.BaseWorkingCopy):
             logger.error("'git --version' output was:\n%s\n%s" % (stdout, stderr))
             sys.exit(1)
 
-        m = re.search(b("git version (\d+)\.(\d+)(\.\d+)?(\.\d+)?"), stdout)
+        m = re.search("git version (\d+)\.(\d+)(\.\d+)?(\.\d+)?", stdout)
         if m is None:
             logger.error("Unable to parse git version output")
             logger.error("'git --version' output was:\n%s\n%s" % (stdout, stderr))
@@ -94,6 +93,7 @@ class GitWorkingCopy(common.BaseWorkingCopy):
         # This should ease things up when multiple processes are trying to send
         # back to the main one large chunks of output
         kwargs['bufsize'] = -1
+        kwargs['universal_newlines'] = True
         return subprocess.Popen(commands, **kwargs)
 
     def git_merge_rbranch(self, stdout_in, stderr_in, accept_missing=False):
@@ -106,7 +106,7 @@ class GitWorkingCopy(common.BaseWorkingCopy):
             raise GitError("'git branch -a' failed.\n%s" % stderr)
         stdout_in += stdout
         stderr_in += stderr
-        if not re.search(b("^(\*| ) %s$" % re.escape(branch)), stdout, re.M):
+        if not re.search("^(\*| ) %s$" % re.escape(branch), stdout, re.M):
             # The branch is not local.  We should not have reached
             # this, unless no branch was specified and we guess wrong
             # that it should be master.
@@ -183,12 +183,12 @@ class GitWorkingCopy(common.BaseWorkingCopy):
             # A tag or revision was specified instead of a branch
             argv = ["checkout", self.source['rev']]
             self.output((logger.info, "Switching to rev '%s'." % self.source['rev']))
-        elif re.search(b("^(\*| ) %s$" % re.escape(branch)), stdout, re.M):
+        elif re.search("^(\*| ) %s$" % re.escape(branch), stdout, re.M):
             # the branch is local, normal checkout will work
             argv = ["checkout", branch]
             self.output((logger.info, "Switching to branch '%s'." % branch))
         elif re.search(
-                b("^  " + re.escape(rbp) + "\/" + re.escape(branch) + "$"),
+                "^  " + re.escape(rbp) + "\/" + re.escape(branch) + "$",
                 stdout, re.M):
             # the branch is not local, normal checkout won't work here
             rbranch = "%s/%s" % (rbp, branch)
@@ -218,6 +218,7 @@ class GitWorkingCopy(common.BaseWorkingCopy):
         cmd = self.run_git(argv, cwd=path)
         stdout, stderr = cmd.communicate()
         if cmd.returncode != 0:
+            import pdb; pdb.set_trace()
             raise GitError("git fetch of '%s' failed.\n%s" % (name, stderr))
         if 'rev' in self.source:
             stdout, stderr = self.git_switch_branch(stdout, stderr)
@@ -260,9 +261,9 @@ class GitWorkingCopy(common.BaseWorkingCopy):
         path = self.source['path']
         cmd = self.run_git(["status", "-s", "-b"], cwd=path)
         stdout, stderr = cmd.communicate()
-        lines = stdout.strip().split(b('\n'))
+        lines = stdout.strip().split('\n')
         if len(lines) == 1:
-            if b('ahead') in lines[0]:
+            if 'ahead' in lines[0]:
                 status = 'ahead'
             else:
                 status = 'clean'
@@ -283,7 +284,7 @@ class GitWorkingCopy(common.BaseWorkingCopy):
         stdout, stderr = cmd.communicate()
         if cmd.returncode != 0:
             raise GitError("git remote of '%s' failed.\n%s" % (name, stderr))
-        return (self.source['url'] in s(stdout).split())
+        return (self.source['url'] in stdout.split())
 
     def update(self, **kwargs):
         name = self.source['name']
@@ -315,9 +316,9 @@ class GitWorkingCopy(common.BaseWorkingCopy):
         stdout, stderr = cmd.communicate()
         if cmd.returncode != 0:
             raise GitError("git submodule init failed.\n")
-        output = s(stdout)
+        output = stdout
         if not output:
-            output = s(stderr)
+            output = stderr
         initialized_submodules = re.findall(
             r'\s+[\'"](.*?)[\'"]\s+\(.+\)',
             output)

--- a/src/mr/developer/tests/test_git.py
+++ b/src/mr/developer/tests/test_git.py
@@ -170,7 +170,10 @@ class TestGit:
                 ('info', ("Updated 'egg' with git.",), {}),
                 ('info', ("Switching to remote branch 'remotes/origin/master'.",), {})]
             captured = capsys.readouterr()
-            assert captured.out == "* develop\n  remotes/origin/HEAD -> origin/develop\n  remotes/origin/develop\n  remotes/origin/master\nBranch master set up to track remote branch master from origin.\n  develop\n* master\n  remotes/origin/HEAD -> origin/develop\n  remotes/origin/develop\n  remotes/origin/master\nAlready up-to-date.\n\n"
+            older = "* develop\n  remotes/origin/HEAD -> origin/develop\n  remotes/origin/develop\n  remotes/origin/master\nBranch master set up to track remote branch master from origin.\n  develop\n* master\n  remotes/origin/HEAD -> origin/develop\n  remotes/origin/develop\n  remotes/origin/master\nAlready up-to-date.\n\n"
+            newer = "* develop\n  remotes/origin/HEAD -> origin/develop\n  remotes/origin/develop\n  remotes/origin/master\nBranch 'master' set up to track remote branch 'master' from 'origin'.\n  develop\n* master\n  remotes/origin/HEAD -> origin/develop\n  remotes/origin/develop\n  remotes/origin/master\nAlready up to date.\n\n"
+            # git output varies between versions...
+            assert captured.out in [older, newer]
             CmdStatus(develop)(develop.parser.parse_args(['status', '-v']))
             captured = capsys.readouterr()
             assert captured.out == "~   A egg\n      ## master...origin/master\n\n"

--- a/src/mr/developer/tests/utils.py
+++ b/src/mr/developer/tests/utils.py
@@ -194,3 +194,6 @@ class GitRepo(object):
         self("git add .gitmodules")
         self("git add %s" % submodule_name)
         self("git commit -m 'Add submodule %s'" % submodule_name)
+
+    def add_branch(self, bname, msg=None):
+        self("git checkout -b %s" % bname)


### PR DESCRIPTION
universal_newlines turns all printed stdout and stderr to text in py3 and str in py2
also add a dumb catch-all-decoder for py3