### PR TITLE
Fix bin/develop help on Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 2.0.1 (Unreleased)
 ------------------
 
+* Fix ``bin/develop help`` on Python 3.
 
 
 2.0.0 (2019-03-04)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -11,6 +11,7 @@ eggs =
     pytest
     pytest-cov
     pytest-flakes
+    pytest-flake8
     pytest-pep8
     mr.developer [test]
 

--- a/src/mr/developer/commands.py
+++ b/src/mr/developer/commands.py
@@ -286,7 +286,7 @@ class CmdHelp(Command):
             if name == 'pony':
                 continue
             cmds.setdefault(choices[name], set()).add(name)
-        for cmd, names in cmds.items():
+        for cmd, names in list(cmds.items()):
             names = list(reversed(sorted(names, key=len)))
             cmds[names[0]] = dict(
                 aliases=names[1:],

--- a/src/mr/developer/tests/test_commands.py
+++ b/src/mr/developer/tests/test_commands.py
@@ -130,3 +130,16 @@ class TestDeactivateCommand:
         assert logger.mock_calls == [
             ('info', ("Deactivated 'foo'.",), {}),
             ('warn', ("Don't forget to run buildout again, so the deactived packages are actually not used anymore.",), {})]
+
+
+class TestHelpCommand:
+    @pytest.fixture
+    def cmd(self, develop):
+        from mr.developer.commands import CmdHelp
+        return CmdHelp(develop)
+
+    def testHelp(self, cmd, develop, capsys):
+        args = develop.parser.parse_args(args=['help'])
+        cmd(args)
+        out, err = capsys.readouterr()
+        assert 'Available commands' in out


### PR DESCRIPTION
Without this fix I get:

```python
$ bin/develop help
Traceback (most recent call last):
  File "bin/develop", line 13, in <module>
    sys.exit(mr.developer.develop.develop())
  File ".../mr.developer-2.0.0-py3.7.egg/mr/developer/develop.py", line 103, in __call__
    args.func(args)
  File ".../mr.developer-2.0.0-py3.7.egg/mr/developer/commands.py", line 289, in __call__
    for cmd, names in cmds.items():
RuntimeError: dictionary changed size during iteration
```