### PR TITLE
[FIX] Mock's patch contextmanager now requires exc_info like arguments

### DIFF
--- a/src/mr/developer/tests/test_commands.py
+++ b/src/mr/developer/tests/test_commands.py
@@ -92,7 +92,7 @@ class TestDeactivateCommand:
         try:
             cmd(args)
         finally:
-            _logger.__exit__()
+            _logger.__exit__(None, None, None)
         assert develop.config.develop == dict(
             bar=False,
             foo='auto',
@@ -107,7 +107,7 @@ class TestDeactivateCommand:
         try:
             cmd(args)
         finally:
-            _logger.__exit__()
+            _logger.__exit__(None, None, None)
         assert develop.config.develop == dict(
             bar=False,
             foo='auto',
@@ -123,7 +123,7 @@ class TestDeactivateCommand:
         try:
             cmd(args)
         finally:
-            _logger.__exit__()
+            _logger.__exit__(None, None, None)
         assert develop.config.develop == dict(
             foo=False,
             ham='auto')

--- a/src/mr/developer/tests/test_extension.py
+++ b/src/mr/developer/tests/test_extension.py
@@ -271,7 +271,7 @@ class TestExtensionClass:
 
             (develop, develeggs, versions) = extension.get_develop_info()
         finally:
-            _exists.__exit__()
+            _exists.__exit__(None, None, None)
         assert buildout['versions'] == {
             'pkg.foo-bar': '',
             'pkg.bar-foo': '1.0'}
@@ -296,7 +296,7 @@ class TestExtensionClass:
             exists().return_value = True
             (develop, develeggs, versions) = extension.get_develop_info()
         finally:
-            _exists.__exit__()
+            _exists.__exit__(None, None, None)
         assert develop == ['/normal/develop', '/develop/with/slash/', 'src/pkg.bar']
 
     def testMissingSourceSection(self, buildout, extension):

--- a/src/mr/developer/tests/test_git.py
+++ b/src/mr/developer/tests/test_git.py
@@ -139,7 +139,7 @@ class TestGit:
             assert captured.out == "~   A egg\n      ## master...origin/master\n\n"
 
         finally:
-            _log.__exit__()
+            _log.__exit__(None, None, None)
 
     def testUpdateVerbose(self, develop, mkgitrepo, src, capsys):
         from mr.developer.commands import CmdCheckout
@@ -178,7 +178,7 @@ class TestGit:
             assert captured.out == "~   A egg\n      ## master...origin/master\n\n"
 
         finally:
-            _log.__exit__()
+            _log.__exit__(None, None, None)
 
     def testDepthOption(self, mkgitrepo, src, tempdir):
         from mr.developer.develop import develop

--- a/src/mr/developer/tests/test_git_submodules.py
+++ b/src/mr/developer/tests/test_git_submodules.py
@@ -33,7 +33,7 @@ class TestGitSubmodules:
                 ('info', ("Cloned 'egg' with git from '%s'." % egg.url,), {}),
                 ('info', ("Initialized 'egg' submodule at '%s' with git." % submodule_name,), {})]
         finally:
-            _log.__exit__()
+            _log.__exit__(None, None, None)
 
     def testCheckoutWithTwoSubmodules(self, develop, mkgitrepo, src):
         """
@@ -71,7 +71,7 @@ class TestGitSubmodules:
                 ('info', ("Initialized 'egg' submodule at '%s' with git." % submodule_name,), {}),
                 ('info', ("Initialized 'egg' submodule at '%s' with git." % submodule_b_name,), {})]
         finally:
-            _log.__exit__()
+            _log.__exit__(None, None, None)
 
     def testUpdateWithSubmodule(self, develop, mkgitrepo, src):
         """
@@ -102,7 +102,7 @@ class TestGitSubmodules:
                 ('info', ("Cloned 'egg' with git from '%s'." % egg.url,), {}),
                 ('info', ("Initialized 'egg' submodule at '%s' with git." % submodule_name,), {})]
         finally:
-            _log.__exit__()
+            _log.__exit__(None, None, None)
 
         submodule_b_name = 'submodule_b'
         submodule_b = mkgitrepo(submodule_b_name)
@@ -119,7 +119,7 @@ class TestGitSubmodules:
                 ('info', ("Switching to branch 'master'.",), {}),
                 ('info', ("Initialized 'egg' submodule at '%s' with git." % submodule_b_name,), {})]
         finally:
-            _log.__exit__()
+            _log.__exit__(None, None, None)
 
     def testCheckoutWithSubmodulesOptionNever(self, develop, mkgitrepo, src):
         """
@@ -151,7 +151,7 @@ class TestGitSubmodules:
             assert log.method_calls == [
                 ('info', ("Cloned 'egg' with git from '%s'." % egg.url,), {})]
         finally:
-            _log.__exit__()
+            _log.__exit__(None, None, None)
 
     def testCheckoutWithSubmodulesOptionNeverSourceAlways(self, develop, mkgitrepo, src):
         """
@@ -199,7 +199,7 @@ class TestGitSubmodules:
                 ('info', ("Initialized 'egg' submodule at '%s' with git." % submodule_name,), {}),
                 ('info', ("Cloned 'egg2' with git from '%s'." % egg2.url,), {})]
         finally:
-            _log.__exit__()
+            _log.__exit__(None, None, None)
 
     def testCheckoutWithSubmodulesOptionAlwaysSourceNever(self, develop, mkgitrepo, src):
         """
@@ -246,7 +246,7 @@ class TestGitSubmodules:
                 ('info', ("Initialized 'egg' submodule at '%s' with git." % submodule_name,), {}),
                 ('info', ("Cloned 'egg2' with git from '%s'." % egg2.url,), {})]
         finally:
-            _log.__exit__()
+            _log.__exit__(None, None, None)
 
     def testUpdateWithSubmoduleCheckout(self, develop, mkgitrepo, src):
         """
@@ -278,7 +278,7 @@ class TestGitSubmodules:
                 ('info', ("Cloned 'egg' with git from '%s'." % egg.url,), {}),
                 ('info', ("Initialized 'egg' submodule at '%s' with git." % submodule_name,), {})]
         finally:
-            _log.__exit__()
+            _log.__exit__(None, None, None)
 
         submodule_b_name = 'submodule_b'
         submodule_b = mkgitrepo(submodule_b_name)
@@ -294,7 +294,7 @@ class TestGitSubmodules:
                 ('info', ("Updated 'egg' with git.",), {}),
                 ('info', ("Switching to branch 'master'.",), {})]
         finally:
-            _log.__exit__()
+            _log.__exit__(None, None, None)
 
     def testUpdateWithSubmoduleDontUpdatePreviousSubmodules(self, develop, mkgitrepo, src):
         """
@@ -326,7 +326,7 @@ class TestGitSubmodules:
                 ('info', ("Cloned 'egg' with git from '%s'." % egg.url,), {}),
                 ('info', ("Initialized 'egg' submodule at '%s' with git." % submodule_name,), {})]
         finally:
-            _log.__exit__()
+            _log.__exit__(None, None, None)
 
         repo = GitRepo(src['egg/%s' % submodule_name])
         repo.setup_user()
@@ -341,4 +341,4 @@ class TestGitSubmodules:
                 ('info', ("Updated 'egg' with git.",), {}),
                 ('info', ("Switching to branch 'master'.",), {})]
         finally:
-            _log.__exit__()
+            _log.__exit__(None, None, None)

--- a/src/mr/developer/tests/test_mercurial.py
+++ b/src/mr/developer/tests/test_mercurial.py
@@ -43,7 +43,7 @@ class TestMercurial:
                 ('info', ("Updated 'egg' with mercurial.",), {}),
                 ('info', ("Switched 'egg' to default.",), {})]
         finally:
-            _log.__exit__()
+            _log.__exit__(None, None, None)
 
     def testUpdateWithRevisionPin(self, develop, src, tempdir):
         from mr.developer.commands import CmdCheckout

--- a/src/mr/developer/tests/test_svn.py
+++ b/src/mr/developer/tests/test_svn.py
@@ -46,7 +46,7 @@ class TestSVN:
                 ('info', ("Checked out 'egg' with subversion.",), {}),
                 ('info', ("Updated 'egg' with subversion.",), {})]
         finally:
-            _log.__exit__()
+            _log.__exit__(None, None, None)
 
     def testUpdateWithRevisionPin(self, develop, src, tempdir):
         from mr.developer.commands import CmdCheckout

--- a/src/mr/developer/tests/utils.py
+++ b/src/mr/developer/tests/utils.py
@@ -101,7 +101,7 @@ def popen(cmd, echo=True, echo2=True, env=None, cwd=None):
     try:
         lines = tee(process, echo)
     finally:
-        bt.__exit__()
+        bt.__exit__(None, None, None)
     return process.returncode, lines
 
 


### PR DESCRIPTION
Fixes

```
  File "/home/user/mr.developer/.tox/py38/lib/python3.8/site-packages/mock/mock.py", line 1545, in __exit__
    return exit_stack.__exit__(*exc_info)
  File "/usr/lib/python3.8/contextlib.py", line 483, in __exit__
    received_exc = exc_details[0] is not None
IndexError: tuple index out of rang
```

when running tests