### PR TITLE
Fix ModuleNotFoundError with setuptools 80.2.0 or higher.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 2.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix ``ModuleNotFoundError`` when trying to import ``safe_name`` from ``setuptools`` 80.2.0 or higher.
+  [maurits]
 
 
 2.0.2 (2024-04-24)

--- a/src/mr/developer/extension.py
+++ b/src/mr/developer/extension.py
@@ -1,5 +1,4 @@
 from mr.developer.common import memoize, WorkingCopies, Config, get_workingcopytypes
-from setuptools.package_index import safe_name
 import logging
 import os
 import re
@@ -9,6 +8,17 @@ import sys
 FAKE_PART_ID = '_mr.developer'
 
 logger = logging.getLogger("mr.developer")
+
+
+def safe_name(name: str) -> str:
+    """Convert an arbitrary string to a standard distribution name
+
+    Any runs of non-alphanumeric/. characters are replaced with a single '-'.
+
+    This is copied from pkg_resources.safe_name.
+    (formerly setuptools.package_index.safe_name)
+    """
+    return re.sub('[^A-Za-z0-9.]+', '-', name)
 
 
 class Source(dict):


### PR DESCRIPTION
Sample error:

```
.tox/py312/lib/python3.12/site-packages/mr/developer/extension.py:2: in <module>
    from setuptools.package_index import safe_name
E   ModuleNotFoundError: No module named 'setuptools.package_index'
```

`setuptools` 80.2.0 removes the `package_index` module. When it still existed, this actually imported `safe_name` from `pkg_resources`. This may depend on the setuptools version as well, and `pkg_resources` will be removed at the end of the year. So I copied the only thing we needed: the `safe_name` function.

Note that we don't have CI setup on master currently.  But @mamico has added that in PR #212.  So we should get that PR merged soon as well.  (And I would also fully drop Python 2 support, and Python 3.8 and lower.)