### PR TITLE
Restore compatibility with Python 2.7.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 2.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Restore compatibility with Python 2.7, accidentally broken in last release.
+  [maurits]
 
 
 2.0.3 (2025-06-04)

--- a/src/mr/developer/extension.py
+++ b/src/mr/developer/extension.py
@@ -10,7 +10,7 @@ FAKE_PART_ID = '_mr.developer'
 logger = logging.getLogger("mr.developer")
 
 
-def safe_name(name: str) -> str:
+def safe_name(name):
     """Convert an arbitrary string to a standard distribution name
 
     Any runs of non-alphanumeric/. characters are replaced with a single '-'.


### PR DESCRIPTION
This was accidentally broken in the last release.
Fixes issue #214.